### PR TITLE
Mingw support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,5 @@
+ACLOCAL_AMFLAGS = -I m4
+
 SUBDIRS =  src includes
 
 pkgconfigdir = $(libdir)/pkgconfig

--- a/configure.ac
+++ b/configure.ac
@@ -4,8 +4,17 @@ AC_PREREQ(2.50)
 AC_INIT( [OIS], 1.4.0 )
 
 AC_CANONICAL_TARGET
-AM_INIT_AUTOMAKE( [OIS], 1.4.0 )
+AM_INIT_AUTOMAKE([subdir-objects])
 AM_CONFIG_HEADER([includes/config.h])
+AC_CONFIG_MACRO_DIR([m4])
+
+case "$host" in
+        *-*-mingw*|*-*-cygwin*)
+                lt_cv_deplibs_check_method='pass_all'
+        ;;
+esac
+
+LT_INIT
 
 dnl Check for programs
 AC_PROG_CC
@@ -21,8 +30,35 @@ CFLAGS="$CFLAGS"
 CXXFLAGS="$CXXFLAGS"
 LIBS="$LIBS"
 
-dnl Detect X11
-AC_CHECK_HEADERS([X11/Xlib.h],, [AC_MSG_ERROR("Xlib.h not found - libx11-dev")])
+case "$host" in
+        *-*-mingw*|*-*-cygwin*)
+                AC_DEFINE(PLATFORM_WIN32, 1, [Platform is Win32])
+                AM_CONDITIONAL([PLATFORM_WIN32], [test xtest = xtest])
+                AM_CONDITIONAL([PLATFORM_LINUX], [test xno = xtest])
+                AM_CONDITIONAL([PLATFORM_APPLE], [test xno = xtest])
+                PLATFORM_STRING="Win32"
+                ;;
+        *-*-linux*)
+                AC_DEFINE(PLATFORM_LINUX, 1, [Platform is Linux])
+                PLATFORM_STRING="Linux"
+                AM_CONDITIONAL([PLATFORM_WIN32], [test xno = xtest])
+                AM_CONDITIONAL([PLATFORM_LINUX], [test xtest = xtest])
+                AM_CONDITIONAL([PLATFORM_APPLE], [test xno = xtest])
+                dnl Detect X11
+                AC_CHECK_HEADERS([X11/Xlib.h],, [AC_MSG_ERROR("Xlib.h not found - libx11-dev")])
+                ;;
+        *-*-darwin*)
+                AC_MSG_WARN([Hello])
+                AC_DEFINE(PLATFORM_APPLE, 1, [Platform is Apple])
+                PLATFORM_STRING="Apple"
+                AM_CONDITIONAL([PLATFORM_WIN32], [test xno = xtest])
+                AM_CONDITIONAL([PLATFORM_LINUX], [test xno = xtest])
+                AM_CONDITIONAL([PLATFORM_APPLE], [test xtest = xtest])
+                ;;
+        *)
+                AC_MSG_WARN([*** Please add $host to configure.ac checks!])
+                ;;
+esac
 
 dnl Added for BSD's
 AC_PROG_LIBTOOL

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,8 @@ AC_INIT( [OIS], 1.4.0 )
 
 AC_CANONICAL_TARGET
 AM_INIT_AUTOMAKE([subdir-objects])
-AM_CONFIG_HEADER([includes/config.h])
+AM_INIT_AUTOMAKE
+AC_CONFIG_HEADER([includes/config.h])
 AC_CONFIG_MACRO_DIR([m4])
 
 case "$host" in

--- a/demos/FFConsoleDemo.cpp
+++ b/demos/FFConsoleDemo.cpp
@@ -7,6 +7,7 @@
 #include <ios>
 #include <sstream>
 #include <vector>
+#include <unistd.h>
 
 using namespace std;
 

--- a/demos/Makefile.am
+++ b/demos/Makefile.am
@@ -1,11 +1,25 @@
-INCLUDES = $(STLPORT_CFLAGS) -I$(top_srcdir)/includes $(CFLAGS) -I/usr/X11R6/include
+if PLATFORM_LINUX
+AM_CPPFLAGS = $(STLPORT_CFLAGS) -I$(top_srcdir)/includes $(CFLAGS) -I/usr/X11R6/include
+endif
+
+if PLATFORM_WIN32
+AM_CPPFLAGS = $(STLPORT_CFLAGS) -I$(top_srcdir)/includes -I$(top_srcdir)/Win32/CommandLine $(CFLAGS)
+endif
 
 noinst_PROGRAMS = ConsoleApp FFConsoleTest
 
-ConsoleApp_SOURCES = OISConsole.cpp
+ConsoleApp_SOURCES = OISConsole.cpp $(top_srcdir)/Win32/CommandLine/CommandLine.rc
 ConsoleApp_LDFLAGS = -L$(top_builddir)/src
+if PLATFORM_WIN32
+ConsoleApp_LDADD = -lOIS -ldinput8 -ldxguid -lole32 -loleaut32 -luser32
+else
 ConsoleApp_LDADD = -lOIS
+endif
 
-FFConsoleTest_SOURCES = FFConsoleDemo.cpp
+FFConsoleTest_SOURCES = FFConsoleDemo.cpp $(top_srcdir)/Win32/DemoFFTest/FF.rc
 FFConsoleTest_LDFLAGS = -L$(top_builddir)/src
+if PLATFORM_WIN32
+FFConsoleTest_LDADD = -lOIS -ldinput8 -ldxguid -lole32 -loleaut32 -luser32
+else
 FFConsoleTest_LDADD = -lOIS
+endif

--- a/demos/OISConsole.cpp
+++ b/demos/OISConsole.cpp
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <vector>
 #include <sstream>
+#include <unistd.h>
 
 ////////////////////////////////////Needed Windows Headers////////////
 #if defined OIS_WIN32_PLATFORM

--- a/includes/win32/Win32Prereqs.h
+++ b/includes/win32/Win32Prereqs.h
@@ -29,6 +29,15 @@ restrictions:
 #include <windows.h>
 #include <dinput.h>
 
+#ifdef __MINGW32__
+#ifndef IDirectInput8
+#define IDirectInput8 IDirectInput8A
+#endif
+#ifndef IDirectInputDevice8
+#define IDirectInputDevice8 IDirectInputDevice8A
+#endif
+#endif
+
 #ifdef OIS_WIN32_XINPUT_SUPPORT
 #	include <XInput.h>
 #endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,8 +12,8 @@ libOIS_la_SOURCES = OISInputManager.cpp \
 	OISException.cpp \
 	./linux/EventHelpers.cpp \
 	./linux/LinuxInputManager.cpp \
-        ./linux/LinuxJoyStickEvents.cpp \
-        ./linux/LinuxForceFeedback.cpp \
+    ./linux/LinuxJoyStickEvents.cpp \
+    ./linux/LinuxForceFeedback.cpp \
 	./linux/LinuxKeyboard.cpp \
 	./linux/LinuxMouse.cpp
 
@@ -37,8 +37,8 @@ libOIS_la_SOURCES = OISInputManager.cpp \
 	OISForceFeedback.cpp \
 	OISException.cpp \
 	./win32/Win32InputManager.cpp \
-        ./win32/Win32JoyStick.cpp \
-        ./win32/Win32ForceFeedback.cpp \
+    ./win32/Win32JoyStick.cpp \
+    ./win32/Win32ForceFeedback.cpp \
 	./win32/Win32KeyBoard.cpp \
 	./win32/Win32Mouse.cpp
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,6 @@
-INCLUDES = $(STLPORT_CFLAGS) -I$(top_srcdir)/includes $(CFLAGS) -I/usr/X11R6/include
+if PLATFORM_LINUX
 
-
+AM_CPPFLAGS = $(STLPORT_CFLAGS) -I$(top_srcdir)/includes $(CFLAGS) -I/usr/X11R6/include
 
 lib_LTLIBRARIES=libOIS.la
 libOIS_la_SOURCES = OISInputManager.cpp \
@@ -22,4 +22,30 @@ libOIS_la_LDFLAGS = -release @PACKAGE_VERSION@
 
 libOIS_la_LIBADD = $(STLPORT_LIBS) -L/usr/X11R6/lib -lX11
 
+endif
+
+if PLATFORM_WIN32
+
+AM_CPPFLAGS = $(STLPORT_CFLAGS) -I$(top_srcdir)/includes $(CFLAGS) -DWIN32 -DOIS_DYNAMIC_LIB -DOIS_NONCLIENT_BUILD
+
+lib_LTLIBRARIES=libOIS.la
+libOIS_la_SOURCES = OISInputManager.cpp \
+	OISObject.cpp \
+	OISEffect.cpp \
+	OISJoyStick.cpp \
+	OISKeyboard.cpp \
+	OISForceFeedback.cpp \
+	OISException.cpp \
+	./win32/Win32InputManager.cpp \
+        ./win32/Win32JoyStick.cpp \
+        ./win32/Win32ForceFeedback.cpp \
+	./win32/Win32KeyBoard.cpp \
+	./win32/Win32Mouse.cpp
+
+libOIS_la_LDFLAGS = -Wl,--enable-auto-image-base -Wl,--add-stdcall-alias -Wl,--out-implib,libOIS.dll.a -no-undefined -release @PACKAGE_VERSION@
+#libOIS_la_LDFLAGS = -version-info $(shell echo "@PACKAGE_VERSION@" | tr '.' ':')
+
+libOIS_la_LIBADD = $(STLPORT_LIBS) -ldinput8 -ldxguid -lole32 -loleaut32 -luser32
+
+endif
 #eof "$Id: Makefile.am,v 1.15.2.1 2008/02/14 03:33:36 pjcast Exp $"

--- a/src/linux/LinuxForceFeedback.cpp
+++ b/src/linux/LinuxForceFeedback.cpp
@@ -26,6 +26,7 @@ restrictions:
 #include <cstdlib>
 #include <errno.h>
 #include <memory.h>
+#include <unistd.h>
 
 using namespace OIS;
 

--- a/src/linux/LinuxJoyStickEvents.cpp
+++ b/src/linux/LinuxJoyStickEvents.cpp
@@ -33,6 +33,7 @@ restrictions:
 #include <fcntl.h>        //Needed to Open a file descriptor
 #include <cassert>
 #include <linux/input.h>
+#include <unistd.h>
 
 
 #include <sstream>

--- a/src/win32/Win32ForceFeedback.cpp
+++ b/src/win32/Win32ForceFeedback.cpp
@@ -195,7 +195,12 @@ void Win32ForceFeedback::_updateConstantEffect( const Effect* effect )
 {
 	ConstantEffect *eff = static_cast<ConstantEffect*>(effect->getForceEffect());
 
+	//FIXME: Not implemented in mingw yet
+#ifdef __MINGW32__
+	DWORD           rgdwAxes[2]     = { 0, 4 };
+#else
 	DWORD           rgdwAxes[2]     = { DIJOFS_X, DIJOFS_Y };
+#endif
 	LONG            rglDirection[2] = { 0, 0 };
 	DIENVELOPE      diEnvelope;
 	DICONSTANTFORCE cf;
@@ -219,7 +224,12 @@ void Win32ForceFeedback::_updateRampEffect( const Effect* effect )
 {
 	RampEffect *eff = static_cast<RampEffect*>(effect->getForceEffect());
 
+	//FIXME: Not implemented in mingw yet
+#ifdef __MINGW32__
+	DWORD           rgdwAxes[2]     = { 0, 4 };
+#else
 	DWORD           rgdwAxes[2]     = { DIJOFS_X, DIJOFS_Y };
+#endif
 	LONG            rglDirection[2] = { 0, 0 };
 	DIENVELOPE      diEnvelope;
 	DIRAMPFORCE     rf;
@@ -238,7 +248,12 @@ void Win32ForceFeedback::_updatePeriodicEffect( const Effect* effect )
 {
 	PeriodicEffect *eff = static_cast<PeriodicEffect*>(effect->getForceEffect());
 
+	//FIXME: Not implemented in mingw yet
+#ifdef __MINGW32__
+	DWORD           rgdwAxes[2]     = { 0, 4 };
+#else
 	DWORD           rgdwAxes[2]     = { DIJOFS_X, DIJOFS_Y };
+#endif
 	LONG            rglDirection[2] = { 0, 0 };
 	DIENVELOPE      diEnvelope;
 	DIPERIODIC      pf;
@@ -268,7 +283,12 @@ void Win32ForceFeedback::_updateConditionalEffect( const Effect* effect )
 {
 	ConditionalEffect *eff = static_cast<ConditionalEffect*>(effect->getForceEffect());
 
+	//FIXME: Not implemented in mingw yet
+#ifdef __MINGW32__
+	DWORD           rgdwAxes[2]     = { 0, 4 };
+#else
 	DWORD           rgdwAxes[2]     = { DIJOFS_X, DIJOFS_Y };
+#endif
 	LONG            rglDirection[2] = { 0, 0 };
 	DIENVELOPE      diEnvelope;
 	DICONDITION     cf;

--- a/src/win32/Win32JoyStick.cpp
+++ b/src/win32/Win32JoyStick.cpp
@@ -284,6 +284,92 @@ void Win32JoyStick::capture()
 						  false,false,false,false,false,false,false,false};
 	bool sliderMoved[4] = {false,false,false,false};
 
+   //FIXME: Not implemented in mingw yet
+#ifdef __MINGW32__
+
+   //Loop through all the events
+   for(unsigned int i = 0; i < entries; ++i)
+   {
+       //This may seem outof order, but is in order of the way these variables
+       //are declared in the JoyStick State 2 structure.
+       switch(diBuff[i].dwOfs)
+       {
+       //------ slider -//
+       case 24:
+           sliderMoved[0] = true;
+           mState.mSliders[0].abX = diBuff[i].dwData;
+           break;
+       case 28:
+           sliderMoved[0] = true;
+           mState.mSliders[0].abY = diBuff[i].dwData;
+           break;
+       //----- Max 4 POVs Next ---------------//
+       case 32:
+           if(!_changePOV(0,diBuff[i]))
+               return;
+           break;
+       case 36:
+           if(!_changePOV(1,diBuff[i]))
+               return;
+           break;
+       case 40:
+           if(!_changePOV(2,diBuff[i]))
+               return;
+           break;
+       case 44:
+           if(!_changePOV(3,diBuff[i]))
+               return;
+           break;
+//FIXME: Strange not in mingw at all
+/*     case DIJOFS_SLIDER1(0):
+           sliderMoved[1] = true;
+           mState.mSliders[1].abX = diBuff[i].dwData;
+           break;
+       case DIJOFS_SLIDER1(1):
+           sliderMoved[1] = true;
+           mState.mSliders[1].abY = diBuff[i].dwData;
+           break;
+       case DIJOFS_SLIDER2(0):
+           sliderMoved[2] = true;
+           mState.mSliders[2].abX = diBuff[i].dwData;
+           break;
+       case DIJOFS_SLIDER2(1):
+           sliderMoved[2] = true;
+           mState.mSliders[2].abY = diBuff[i].dwData;
+           break;
+       case DIJOFS_SLIDER3(0):
+           sliderMoved[3] = true;
+           mState.mSliders[3].abX = diBuff[i].dwData;
+           break;
+       case DIJOFS_SLIDER3(1):
+           sliderMoved[3] = true;
+           mState.mSliders[3].abY = diBuff[i].dwData;
+           break;*/
+       //-----------------------------------------//
+       default:
+           //Handle Button Events Easily using the DX Offset Macros
+           if( diBuff[i].dwOfs >= 48 && diBuff[i].dwOfs < 176 )
+           {
+               if(!_doButtonClick((diBuff[i].dwOfs - 48), diBuff[i]))
+                   return;
+           }
+           else if((short)(diBuff[i].uAppData >> 16) == 0x1313)
+           {   //If it was nothing else, might be axis enumerated earlier (determined by magic number)
+               int axis = (int)(0x0000FFFF & diBuff[i].uAppData); //Mask out the high bit
+               assert( axis >= 0 && axis < (int)mState.mAxes.size() && "Axis out of range!");
+
+               if(axis >= 0 && axis < (int)mState.mAxes.size())
+               {
+                   mState.mAxes[axis].abs = diBuff[i].dwData;
+                   axisMoved[axis] = true;
+               }
+           }
+
+           break;
+       } //end case
+   } //end for
+#else
+
 	//Loop through all the events
 	for(unsigned int i = 0; i < entries; ++i)
 	{
@@ -364,6 +450,7 @@ void Win32JoyStick::capture()
 			break;
 		} //end case
 	} //end for
+#endif
 
 	//Check to see if any of the axes values have changed.. if so send events
 	if( mBuffered && mListener && entries > 0 )
@@ -584,12 +671,12 @@ void Win32JoyStick::CheckXInputDevices(JoyStickInfoList &joys)
     // CoInit if needed
     hr = CoInitialize(NULL);
     bool bCleanupCOM = SUCCEEDED(hr);
-
+#ifndef __MINGW32__
     // Create WMI
     hr = CoCreateInstance(__uuidof(WbemLocator), NULL, CLSCTX_INPROC_SERVER, __uuidof(IWbemLocator), (LPVOID*)&pIWbemLocator);
     if( FAILED(hr) || pIWbemLocator == NULL )
+#endif
         goto LCleanup;
-
     bstrNamespace = SysAllocString( L"\\\\.\\root\\cimv2" );
 	if( bstrNamespace == NULL )
 		goto LCleanup;
@@ -636,6 +723,7 @@ void Win32JoyStick::CheckXInputDevices(JoyStickInfoList &joys)
                 {
                     // If it does, then get the VID/PID from var.bstrVal
                     DWORD dwPid = 0, dwVid = 0;
+#ifndef __MINGW32__
                     WCHAR* strVid = wcsstr( var.bstrVal, L"VID_" );
                     if(strVid && swscanf_s( strVid, L"VID_%4X", &dwVid ) != 1)
 						dwVid = 0;
@@ -643,6 +731,7 @@ void Win32JoyStick::CheckXInputDevices(JoyStickInfoList &joys)
                     WCHAR* strPid = wcsstr( var.bstrVal, L"PID_" );
                     if(strPid && swscanf_s( strPid, L"PID_%4X", &dwPid ) != 1)
                         dwPid = 0;
+#endif
 
                     // Compare the VID/PID to the DInput device
                     DWORD dwVidPid = MAKELONG(dwVid, dwPid);

--- a/src/win32/Win32Mouse.cpp
+++ b/src/win32/Win32Mouse.cpp
@@ -112,6 +112,52 @@ void Win32Mouse::capture()
 	bool axesMoved = false;
 	//Accumulate all axis movements for one axesMove message..
 	//Buttons are fired off as they are found
+	//FIXME: Not implemented in mingw yet
+#ifdef __MINGW32__
+	for(unsigned int i = 0; i < entries; ++i )
+	{
+		switch( diBuff[i].dwOfs )
+		{
+			case 12:
+				if(!_doMouseClick(0, diBuff[i])) return;
+				break;
+			case 13:
+				if(!_doMouseClick(1, diBuff[i])) return;
+				break;
+			case 14:
+				if(!_doMouseClick(2, diBuff[i])) return;
+				break;
+			case 15:
+				if(!_doMouseClick(3, diBuff[i])) return;
+				break;
+			case 16:
+				if(!_doMouseClick(4, diBuff[i])) return;
+				break;	
+			case 17:
+				if(!_doMouseClick(5, diBuff[i])) return;
+				break;
+			case 18:
+				if(!_doMouseClick(6, diBuff[i])) return;
+				break;
+			case 19:
+				if(!_doMouseClick(7, diBuff[i])) return;
+				break;
+			case 0:
+				mState.X.rel += diBuff[i].dwData;
+				axesMoved = true;
+				break;
+			case 4:
+				mState.Y.rel += diBuff[i].dwData;
+				axesMoved = true;
+				break;
+			case 8:
+				mState.Z.rel += diBuff[i].dwData;
+				axesMoved = true;
+				break;
+			default: break;
+		} //end switch
+	}//end for
+#else
 	for(unsigned int i = 0; i < entries; ++i )
 	{
 		switch( diBuff[i].dwOfs )
@@ -155,6 +201,7 @@ void Win32Mouse::capture()
 			default: break;
 		} //end switch
 	}//end for
+#endif
 
 	if( axesMoved )
 	{


### PR DESCRIPTION
I applied the patches in the patches [Alexpux repository](https://github.com/Alexpux/MINGW-packages/tree/master/mingw-w64-ois) that are used to build the [archlinux mingw-w64-ois package](https://aur.archlinux.org/packages/mingw-w64-ois/), and so, allow to build libOIS with mingw on GNU/Linux.
If #9 is merged, I would like to add the mingw builds to the continuous integration script, and so, make sure the build is perennial.
Please have a look.
