### PR TITLE
improve keyboard

### DIFF
--- a/includes/OISException.h
+++ b/includes/OISException.h
@@ -79,5 +79,7 @@ namespace OIS
 
 //! Use this macro to handle exceptions easily
 #define OIS_EXCEPT( err, str ) throw( OIS::Exception(err, str, __LINE__, __FILE__) )
+//#define OIS_WARN( err, str ) throw( OIS::Exception(err, str, __LINE__, __FILE__) )
+#define OIS_WARN( err, str ) do {} while(0)
 
 #endif //_OIS_EXCEPTION_HEADER_

--- a/includes/OISKeyboard.h
+++ b/includes/OISKeyboard.h
@@ -276,9 +276,11 @@ namespace OIS
 		//! Enum of bit position of modifer
 		enum Modifier
 		{
-			Shift = 0x0000001,
-			Ctrl  = 0x0000010,
-			Alt   = 0x0000100
+			Shift    = 0x0000001,
+			Ctrl     = 0x0000010,
+			Alt      = 0x0000100,
+			CapsLock = 0x0001000,
+			NumLock  = 0x0010000
 		};
 
 		/**

--- a/includes/OISKeyboard.h
+++ b/includes/OISKeyboard.h
@@ -183,13 +183,18 @@ namespace OIS
 	class _OISExport KeyEvent : public EventArg
 	{
 	public:
-		KeyEvent(Object* obj, KeyCode kc, unsigned int txt) : EventArg(obj), key(kc), text(txt) {}
+		KeyEvent(Object* obj, KeyCode kc, unsigned int txt = 0, unsigned int rk = 0, unsigned int mod = 0) :
+			EventArg(obj), key(kc), text(txt), rawKey(rk), modifiers(mod) {}
 		virtual ~KeyEvent() {}
 
 		//! KeyCode of event
 		KeyCode key;
 		//! Text character, depends on current TextTranslationMode
 		unsigned int text;
+		//! Native (depends on platform) key code
+		unsigned int rawKey;
+		//! Modifiers state during the event
+		unsigned int modifiers;
 	};
 
 	/**

--- a/includes/linux/LinuxKeyboard.h
+++ b/includes/linux/LinuxKeyboard.h
@@ -116,6 +116,8 @@ namespace OIS
 		XIC xic;
 		bool grabKeyboard;
 		bool keyFocusLost;
+		int capsLockMask;
+		int numLockMask;
 
 		std::string mGetString;
 	};

--- a/includes/linux/LinuxKeyboard.h
+++ b/includes/linux/LinuxKeyboard.h
@@ -80,8 +80,8 @@ namespace OIS
 			return false;
 		}
 
-		bool _injectKeyDown( KeyCode kc, int text );
-		bool _injectKeyUp( KeyCode kc );
+		bool _injectKeyDown( KeyCode kc, int text, int raw );
+		bool _injectKeyUp( KeyCode kc, int raw );
 		void _handleKeyPress( XEvent& event );
 		void _handleKeyRelease( XEvent& event );
 

--- a/includes/linux/LinuxKeyboard.h
+++ b/includes/linux/LinuxKeyboard.h
@@ -85,6 +85,13 @@ namespace OIS
 		void _handleKeyPress( XEvent& event );
 		void _handleKeyRelease( XEvent& event );
 
+		inline KeyCode XKeyCodeToOISKeyCode( ::KeyCode xkc ) {
+			if (xkc > 8)
+				return static_cast<KeyCode>(xkc - 8);
+			else
+				return KC_UNASSIGNED;
+		}
+		
 		inline KeyCode KeySymToOISKeyCode( KeySym keySym )
 		{
 			if (keySym != NoSymbol)

--- a/includes/linux/LinuxKeyboard.h
+++ b/includes/linux/LinuxKeyboard.h
@@ -26,6 +26,7 @@ restrictions:
 #include "linux/LinuxPrereqs.h"
 #include "OISKeyboard.h"
 #include <X11/Xlib.h>
+#include <X11/XKBlib.h>
 
 namespace OIS
 {
@@ -72,18 +73,37 @@ namespace OIS
 			if(e.type == KeyPress && e.xkey.keycode == event.xkey.keycode && (e.xkey.time - event.xkey.time) < 2)
 			{
 				XNextEvent(display, &e);
+				XFilterEvent(&event, None);
 				return true;
 			}
 
 			return false;
 		}
 
-		bool _injectKeyDown( KeySym key, int text );
-		bool _injectKeyUp( KeySym key );
+		bool _injectKeyDown( KeyCode kc, int text );
+		bool _injectKeyUp( KeyCode kc );
+		void _handleKeyPress( XEvent& event );
+		void _handleKeyRelease( XEvent& event );
 
-		//! 1:1 Conversion Map between X Key Events and OIS KeyCodes
-		typedef std::map<KeySym, KeyCode> XtoOIS_KeyMap;
-		XtoOIS_KeyMap keyConversion;
+		inline KeyCode KeySymToOISKeyCode( KeySym keySym )
+		{
+			if (keySym != NoSymbol)
+			{
+				::KeyCode xkc = XKeysymToKeycode(display, keySym);
+				if (xkc > 8)
+					return static_cast<KeyCode>(xkc - 8);
+			}
+			return KC_UNASSIGNED;
+		}
+		inline KeySym OISKeyCodeToKeySym( KeyCode kc )
+		{
+			if (kc == KC_UNASSIGNED)
+				return NoSymbol;
+
+			::KeyCode xkc = kc + 8;
+
+			return XkbKeycodeToKeysym(display, xkc, 0, 0);
+		}
 
 		//! Depressed Key List
 		char KeyBuffer[256];
@@ -91,6 +111,9 @@ namespace OIS
 		//! X11 Stuff
 		Window window;
 		Display *display;
+		XIM xim;
+		XIMStyle ximStyle;
+		XIC xic;
 		bool grabKeyboard;
 		bool keyFocusLost;
 

--- a/includes/mac/MacKeyboard.h
+++ b/includes/mac/MacKeyboard.h
@@ -71,7 +71,7 @@ namespace OIS
         void populateKeyConversion();
 
         // updates the keybuffer and optionally the eventStack
-        void injectEvent(KeyCode kc, unsigned int time, MacEventType type, unsigned int txt = 0 );
+        void injectEvent(KeyCode kc, unsigned int time, MacEventType type, unsigned int txt = 0, unsigned int raw = 0 );
 
         typedef std::map<UInt32, KeyCode> VirtualtoOIS_KeyMap;
         VirtualtoOIS_KeyMap keyConversion;

--- a/src/SDL/SDLKeyboard.cpp
+++ b/src/SDL/SDLKeyboard.cpp
@@ -173,12 +173,12 @@ void SDLKeyboard::capture()
 		{
 			if( events[i].key.state == SDL_PRESSED )
 			{
-				if( listener->keyPressed(KeyEvent(this, 0, kc, events[i].key.keysym.unicode)) == false )
+				if( listener->keyPressed(KeyEvent(this, 0, kc, events[i].key.keysym.unicode), events[i].key.keysym.sym, mModifiers) == false )
 					break;
 			}
 			else
 			{
-				if( listener->keyReleased(KeyEvent(this, 0, kc, events[i].key.keysym.unicode)) == false )
+				if( listener->keyReleased(KeyEvent(this, 0, kc, events[i].key.keysym.unicode), events[i].key.keysym.sym, mModifiers) == false )
 					break;
 			}
 		}

--- a/src/linux/LinuxKeyboard.cpp
+++ b/src/linux/LinuxKeyboard.cpp
@@ -33,155 +33,13 @@ using namespace OIS;
 #include <iostream>
 //-------------------------------------------------------------------//
 LinuxKeyboard::LinuxKeyboard(InputManager* creator, bool buffered, bool grab)
-	: Keyboard(creator->inputSystemName(), buffered, 0, creator)
+	: Keyboard(creator->inputSystemName(), buffered, 0, creator), xim(0), ximStyle(0), xic(0)
 {
-	setlocale(LC_CTYPE, ""); //Set the locale to (hopefully) the users LANG UTF-8 Env var
-
 	display = 0;
 	window = 0;
 
 	grabKeyboard = grab;
 	keyFocusLost = false;
-
-	//X Key Map to KeyCode
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_1, KC_1));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_2, KC_2));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_3, KC_3));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_4, KC_4));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_5, KC_5));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_6, KC_6));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_7, KC_7));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_8, KC_8));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_9, KC_9));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_0, KC_0));
-
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_BackSpace, KC_BACK));
-
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_minus, KC_MINUS));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_equal, KC_EQUALS));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_space, KC_SPACE));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_comma, KC_COMMA));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_period, KC_PERIOD));
-
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_backslash, KC_BACKSLASH));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_slash, KC_SLASH));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_bracketleft, KC_LBRACKET));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_bracketright, KC_RBRACKET));
-
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Escape,KC_ESCAPE));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Caps_Lock, KC_CAPITAL));
-
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Tab, KC_TAB));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Return, KC_RETURN));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Control_L, KC_LCONTROL));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Control_R, KC_RCONTROL));
-
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_colon, KC_COLON));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_semicolon, KC_SEMICOLON));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_apostrophe, KC_APOSTROPHE));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_grave, KC_GRAVE));
-
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_b, KC_B));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_a, KC_A));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_c, KC_C));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_d, KC_D));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_e, KC_E));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_f, KC_F));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_g, KC_G));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_h, KC_H));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_i, KC_I));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_j, KC_J));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_k, KC_K));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_l, KC_L));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_m, KC_M));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_n, KC_N));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_o, KC_O));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_p, KC_P));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_q, KC_Q));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_r, KC_R));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_s, KC_S));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_t, KC_T));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_u, KC_U));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_v, KC_V));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_w, KC_W));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_x, KC_X));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_y, KC_Y));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_z, KC_Z));
-
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_F1, KC_F1));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_F2, KC_F2));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_F3, KC_F3));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_F4, KC_F4));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_F5, KC_F5));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_F6, KC_F6));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_F7, KC_F7));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_F8, KC_F8));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_F9, KC_F9));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_F10, KC_F10));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_F11, KC_F11));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_F12, KC_F12));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_F13, KC_F13));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_F14, KC_F14));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_F15, KC_F15));
-
-	//Keypad
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_0, KC_NUMPAD0));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_1, KC_NUMPAD1));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_2, KC_NUMPAD2));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_3, KC_NUMPAD3));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_4, KC_NUMPAD4));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_5, KC_NUMPAD5));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_6, KC_NUMPAD6));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_7, KC_NUMPAD7));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_8, KC_NUMPAD8));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_9, KC_NUMPAD9));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_Add, KC_ADD));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_Subtract, KC_SUBTRACT));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_Decimal, KC_DECIMAL));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_Equal, KC_NUMPADEQUALS));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_Divide, KC_DIVIDE));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_Multiply, KC_MULTIPLY));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_Enter, KC_NUMPADENTER));
-
-	//Keypad with numlock off
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_Home, KC_NUMPAD7));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_Up, KC_NUMPAD8));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_Page_Up, KC_NUMPAD9));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_Left, KC_NUMPAD4));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_Begin, KC_NUMPAD5));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_Right, KC_NUMPAD6));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_End, KC_NUMPAD1));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_Down, KC_NUMPAD2));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_Page_Down, KC_NUMPAD3));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_Insert, KC_NUMPAD0));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_Delete, KC_DECIMAL));
-
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Up, KC_UP));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Down, KC_DOWN));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Left, KC_LEFT));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Right, KC_RIGHT));
-
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Page_Up, KC_PGUP));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Page_Down, KC_PGDOWN));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Home, KC_HOME));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_End, KC_END));
-
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Num_Lock, KC_NUMLOCK));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Print, KC_SYSRQ));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Scroll_Lock, KC_SCROLL));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Pause, KC_PAUSE));
-
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Shift_R, KC_RSHIFT));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Shift_L, KC_LSHIFT));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Alt_R, KC_RMENU));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Alt_L, KC_LMENU));
-
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Insert, KC_INSERT));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Delete, KC_DELETE));
-
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Super_L, KC_LWIN));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Super_R, KC_RWIN));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Menu, KC_APPS));
 
 	static_cast<LinuxInputManager*>(mCreator)->_setKeyboardUsed(true);
 }
@@ -189,6 +47,10 @@ LinuxKeyboard::LinuxKeyboard(InputManager* creator, bool buffered, bool grab)
 //-------------------------------------------------------------------//
 void LinuxKeyboard::_initialize()
 {
+	//Set the locale to (hopefully) the users LANG UTF-8 Env var
+	if (setlocale(LC_ALL, "") == NULL)
+		OIS_WARN(E_General, "LinuxKeyboard::_initialize: Failed to set default locale.");
+
 	//Clear our keyboard state buffer
 	memset( &KeyBuffer, 0, 256 );
 	mModifiers = 0;
@@ -201,9 +63,57 @@ void LinuxKeyboard::_initialize()
 	if( !(display = XOpenDisplay(0)) )
 		OIS_EXCEPT(E_General, "LinuxKeyboard::_initialize >> Error opening X!");
 
-	//Set it to recieve Input events
+	//Configure locale modifiers
+	if ( XSetLocaleModifiers("@im=none") == NULL)
+		OIS_WARN(E_General, "LinuxKeyboard::_initialize: Failed to configure locale modifiers.");
+
+	//Open input method
+	xim = XOpenIM(display, NULL, NULL, NULL);
+	if ( !xim )
+	{
+		OIS_WARN(E_General, "LinuxKeyboard::_initialize: Failed to open input method.");
+	}
+	else
+	{
+		XIMStyles *ximStyles;
+		char *ret = XGetIMValues(xim, XNQueryInputStyle, &ximStyles, NULL);
+		if ( ret != NULL || ximStyles == NULL )
+		{
+			OIS_WARN(E_General, "LinuxKeyboard::_initialize: Input method does not support any styles.");
+		}
+		else
+		{
+			ximStyle = 0;
+			for (int i = 0; i < ximStyles->count_styles; i++)
+			{
+				if ( ximStyles->supported_styles[i] == (XIMPreeditNothing | XIMStatusNothing) )
+				{
+					ximStyle = ximStyles->supported_styles[i];
+					break;
+				}
+			}
+
+			if (ximStyle == 0)
+				OIS_WARN(E_General, "LinuxKeyboard::_initialize: Input method does not support the requested style.");
+
+			XFree( ximStyles );
+		}
+	}
+
+	//Set it to receive Input events
 	if( XSelectInput(display, window, KeyPressMask | KeyReleaseMask) == BadWindow )
 		OIS_EXCEPT(E_General, "LinuxKeyboard::_initialize: X error!");
+
+	if ( xim && ximStyle )
+	{
+		xic = XCreateIC(xim,
+				XNInputStyle, ximStyle,
+				XNClientWindow, window,
+				XNFocusWindow, window,
+				NULL);
+		if ( !xic )
+			OIS_WARN(E_General, "LinuxKeyboard::_initialize: Failed to create input context.");
+	}
 
 	if( grabKeyboard )
 		XGrabKeyboard(display,window,True,GrabModeAsync,GrabModeAsync,CurrentTime);
@@ -218,6 +128,12 @@ LinuxKeyboard::~LinuxKeyboard()
 	{
 		if( grabKeyboard )
 			XUngrabKeyboard(display, CurrentTime);
+
+		if ( xic )
+			XDestroyIC(xic);
+
+		if ( xim )
+			XCloseIM(xim);
 
 		XCloseDisplay(display);
 	}
@@ -277,9 +193,7 @@ bool LinuxKeyboard::isKeyDown( KeyCode key ) const
 //-------------------------------------------------------------------//
 void LinuxKeyboard::capture()
 {
-	KeySym key;
 	XEvent event;
-	LinuxInputManager* linMan = static_cast<LinuxInputManager*>(mCreator);
 
 	while( XPending(display) > 0 )
 	{
@@ -287,51 +201,19 @@ void LinuxKeyboard::capture()
 
 		if(KeyPress == event.type)
 		{
-			unsigned int character = 0;
-
-			if(mTextMode != Off)
-			{
-				unsigned char buffer[6] = {0,0,0,0,0,0};
-				XLookupString(&event.xkey, (char*)buffer, 6, &key, 0);
-
-				if( mTextMode == Unicode )
-					character = UTF8ToUTF32(buffer);
-				else if( mTextMode == Ascii)
-					character = buffer[0];
-			}
-
-			//Mask out the modifier states X11 sets and read again
-			event.xkey.state &= ~ShiftMask;
-			event.xkey.state &= ~LockMask;
-			XLookupString(&event.xkey, 0, 0,&key, 0);
-
-			_injectKeyDown(key, character);
-
-			//Just printing out some debugging info.. to verify all chars are mapped
-			//std::cout << "KEY PRESSED X=" << event.xkey.keycode;
-			//std::cout << "\n KeySym=" << key << std::endl;
-
-			//Check for Alt-Tab
-			if( event.xkey.state & Mod1Mask && key == XK_Tab )
-				linMan->_setGrabState(false);
+			_handleKeyPress( event );
 		}
 		else if(KeyRelease == event.type)
 		{
-			if(!_isKeyRepeat(event))
-			{
-				//Mask out the modifier states X sets.. or we will get improper values
-				event.xkey.state &= ~ShiftMask;
-				event.xkey.state &= ~LockMask;
-
-				XLookupString(&event.xkey,NULL,0,&key,NULL);
-				_injectKeyUp(key);
-			}
+			_handleKeyRelease( event );
 		}
 	}
 
 	//If grabbing mode is on.. Handle focus lost/gained via Alt-Tab and mouse clicks
 	if( grabKeyboard )
 	{
+		LinuxInputManager* linMan = static_cast<LinuxInputManager*>(mCreator);
+
 		if( linMan->_getGrabState() == false )
 		{
 			// are no longer grabbing
@@ -356,15 +238,77 @@ void LinuxKeyboard::capture()
 }
 
 //-------------------------------------------------------------------//
+void LinuxKeyboard::_handleKeyPress( XEvent& event )
+{
+	XKeyEvent& e = (XKeyEvent&)event;
+	static std::vector<char> buf(32);
+	KeySym keySym;
+	unsigned int character = 0;
+	int bytes = 0;
+	bool haveChar = true;
+
+	haveChar = !XFilterEvent(&event, None);
+
+	if (xic)
+	{
+		Status status;
+		do
+		{
+			bytes = Xutf8LookupString(xic, &e, &buf[0], buf.size()-1, &keySym, &status);
+			buf[bytes] = '\0';
+
+			if (status == XBufferOverflow)
+				buf.resize(buf.size() * 2);
+		} while (status == XBufferOverflow);
+	}
+	else
+	{
+		bytes = XLookupString(&e, &buf[0], buf.size()-1, &keySym, NULL);
+		buf[bytes] = '\0';
+	}
+
+	if (haveChar && bytes > 0)
+	{
+		if( mTextMode == Unicode )
+			character = UTF8ToUTF32(reinterpret_cast<unsigned char*>(&buf[0]));
+		else if( mTextMode == Ascii)
+			character = buf[0];
+	}
+
+	KeyCode kc = KeySymToOISKeyCode(keySym);
+	_injectKeyDown(kc, character);
+
+	//Check for Alt-Tab
+	LinuxInputManager* linMan = static_cast<LinuxInputManager*>(mCreator);
+	if ( (e.state & Mod1Mask) && (keySym == XK_Tab) )
+		linMan->_setGrabState(false);
+}
+
+void LinuxKeyboard::_handleKeyRelease( XEvent& event )
+{
+	XKeyEvent& e = (XKeyEvent&)event;
+	KeySym keySym;
+
+	XFilterEvent(&event, None);
+	if (!_isKeyRepeat(event))
+	{
+		XLookupString(&e, NULL, 0, &keySym, NULL);
+
+		KeyCode kc = KeySymToOISKeyCode(keySym);
+		_injectKeyUp(kc);
+	}
+}
+
+//-------------------------------------------------------------------//
 void LinuxKeyboard::setBuffered(bool buffered)
 {
 	mBuffered = buffered;
 }
 
 //-------------------------------------------------------------------//
-bool LinuxKeyboard::_injectKeyDown( KeySym key, int text )
+bool LinuxKeyboard::_injectKeyDown( KeyCode kc, int text )
 {
-	KeyCode kc = keyConversion[key];
+	if (kc > 255) kc = KC_UNASSIGNED;
 	KeyBuffer[kc] = 1;
 
 	//Turn on modifier flags
@@ -382,9 +326,9 @@ bool LinuxKeyboard::_injectKeyDown( KeySym key, int text )
 }
 
 //-------------------------------------------------------------------//
-bool LinuxKeyboard::_injectKeyUp( KeySym key )
+bool LinuxKeyboard::_injectKeyUp( KeyCode kc )
 {
-	KeyCode kc = keyConversion[key];
+	if (kc > 255) kc = KC_UNASSIGNED;
 	KeyBuffer[kc] = 0;
 
 	//Turn off modifier flags
@@ -406,19 +350,12 @@ const std::string& LinuxKeyboard::getAsString( KeyCode kc )
 {
 	mGetString = "Unknown";
 	char *temp = 0;
-
-	XtoOIS_KeyMap::iterator i = keyConversion.begin(),
-				e = keyConversion.end();
-
-	for( ; i != e; ++i )
+	KeySym sym = OISKeyCodeToKeySym(kc);
+	if (sym != NoSymbol)
 	{
-		if( i->second == kc )
-		{
-			temp = XKeysymToString(i->first);
-			if( temp )
-				mGetString = temp;
-			break;
-		}
+		temp = XKeysymToString(sym);
+		if (temp)
+			mGetString = temp;
 	}
 
 	return mGetString;
@@ -427,12 +364,9 @@ const std::string& LinuxKeyboard::getAsString( KeyCode kc )
 //-------------------------------------------------------------------//
 OIS::KeyCode LinuxKeyboard::getAsKeyCode( std::string str )
 {
-	OIS::KeyCode mGetKeyCode;
+	KeySym X11Key = XStringToKeysym(str.c_str());
 
-    KeySym X11Key = XStringToKeysym(str.c_str());
-    mGetKeyCode = keyConversion.at(X11Key);
-
-	return mGetKeyCode;
+	return KeySymToOISKeyCode(X11Key);
 }
 
 //-------------------------------------------------------------------//

--- a/src/linux/LinuxKeyboard.cpp
+++ b/src/linux/LinuxKeyboard.cpp
@@ -289,7 +289,7 @@ void LinuxKeyboard::_handleKeyPress( XEvent& event )
 	else
 		mModifiers &= ~NumLock;
 
-	KeyCode kc = KeySymToOISKeyCode(keySym);
+	KeyCode kc = XKeyCodeToOISKeyCode(e.keycode);
 	_injectKeyDown(kc, character, keySym);
 
 	//Check for Alt-Tab
@@ -308,7 +308,7 @@ void LinuxKeyboard::_handleKeyRelease( XEvent& event )
 	{
 		XLookupString(&e, NULL, 0, &keySym, NULL);
 
-		KeyCode kc = KeySymToOISKeyCode(keySym);
+		KeyCode kc = XKeyCodeToOISKeyCode(e.keycode);
 		_injectKeyUp(kc, keySym);
 	}
 }

--- a/src/linux/LinuxKeyboard.cpp
+++ b/src/linux/LinuxKeyboard.cpp
@@ -67,6 +67,10 @@ void LinuxKeyboard::_initialize()
 	if ( XSetLocaleModifiers("@im=none") == NULL)
 		OIS_WARN(E_General, "LinuxKeyboard::_initialize: Failed to configure locale modifiers.");
 
+	// Get modifiers masks
+	capsLockMask = XkbKeysymToModifiers(display, XK_Caps_Lock);
+	numLockMask = XkbKeysymToModifiers(display, XK_Num_Lock);
+
 	//Open input method
 	xim = XOpenIM(display, NULL, NULL, NULL);
 	if ( !xim )
@@ -274,6 +278,16 @@ void LinuxKeyboard::_handleKeyPress( XEvent& event )
 		else if( mTextMode == Ascii)
 			character = buf[0];
 	}
+
+	if (e.state & capsLockMask)
+		mModifiers |= CapsLock;
+	else
+		mModifiers &= ~CapsLock;
+	
+	if (e.state & numLockMask)
+		mModifiers |= NumLock;
+	else
+		mModifiers &= ~NumLock;
 
 	KeyCode kc = KeySymToOISKeyCode(keySym);
 	_injectKeyDown(kc, character);

--- a/src/linux/LinuxKeyboard.cpp
+++ b/src/linux/LinuxKeyboard.cpp
@@ -290,7 +290,7 @@ void LinuxKeyboard::_handleKeyPress( XEvent& event )
 		mModifiers &= ~NumLock;
 
 	KeyCode kc = KeySymToOISKeyCode(keySym);
-	_injectKeyDown(kc, character);
+	_injectKeyDown(kc, character, keySym);
 
 	//Check for Alt-Tab
 	LinuxInputManager* linMan = static_cast<LinuxInputManager*>(mCreator);
@@ -309,7 +309,7 @@ void LinuxKeyboard::_handleKeyRelease( XEvent& event )
 		XLookupString(&e, NULL, 0, &keySym, NULL);
 
 		KeyCode kc = KeySymToOISKeyCode(keySym);
-		_injectKeyUp(kc);
+		_injectKeyUp(kc, keySym);
 	}
 }
 
@@ -320,7 +320,7 @@ void LinuxKeyboard::setBuffered(bool buffered)
 }
 
 //-------------------------------------------------------------------//
-bool LinuxKeyboard::_injectKeyDown( KeyCode kc, int text )
+bool LinuxKeyboard::_injectKeyDown( KeyCode kc, int text, int raw )
 {
 	if (kc > 255) kc = KC_UNASSIGNED;
 	KeyBuffer[kc] = 1;
@@ -334,13 +334,13 @@ bool LinuxKeyboard::_injectKeyDown( KeyCode kc, int text )
 		mModifiers |= Alt;
 
 	if( mBuffered && mListener )
-		return mListener->keyPressed(KeyEvent(this,kc,text));
+		return mListener->keyPressed(KeyEvent(this,kc,text,raw,mModifiers));
 
 	return true;
 }
 
 //-------------------------------------------------------------------//
-bool LinuxKeyboard::_injectKeyUp( KeyCode kc )
+bool LinuxKeyboard::_injectKeyUp( KeyCode kc, int raw )
 {
 	if (kc > 255) kc = KC_UNASSIGNED;
 	KeyBuffer[kc] = 0;
@@ -354,7 +354,7 @@ bool LinuxKeyboard::_injectKeyUp( KeyCode kc )
 		mModifiers &= ~Alt;
 
 	if( mBuffered && mListener )
-		return mListener->keyReleased(KeyEvent(this, kc, 0));
+		return mListener->keyReleased(KeyEvent(this, kc, 0, raw,mModifiers));
 
 	return true;
 }

--- a/src/mac/MacKeyboard.cpp
+++ b/src/mac/MacKeyboard.cpp
@@ -218,7 +218,7 @@ void MacKeyboard::_keyDownCallback( EventRef theEvent )
 			stringsize--; // no termination char
 			for ( int i = 0; i < stringsize; i++ )
 			{
-				injectEvent( kc, time, MAC_KEYDOWN, (unsigned int)text[i] );
+				injectEvent( kc, time, MAC_KEYDOWN, (unsigned int)text[i], virtualKey );
 			}
 		}
 	}
@@ -226,11 +226,11 @@ void MacKeyboard::_keyDownCallback( EventRef theEvent )
 	{
 
 		status = GetEventParameter( theEvent, 'kchr', typeChar, NULL, sizeof(char), NULL, &macChar );
-		injectEvent( kc, time, MAC_KEYDOWN, (unsigned int)macChar );
+		injectEvent( kc, time, MAC_KEYDOWN, (unsigned int)macChar, virtualKey );
 	}
 	else
 	{
-		injectEvent( kc, time, MAC_KEYDOWN );
+		injectEvent( kc, time, MAC_KEYDOWN, 0, virtualKey );
 	}
 }
 
@@ -309,13 +309,13 @@ void MacKeyboard::_modChangeCallback( EventRef theEvent )
 }
 
 //-------------------------------------------------------------------//
-void MacKeyboard::injectEvent( KeyCode kc, unsigned int time, MacEventType type, unsigned int txt )
+void MacKeyboard::injectEvent( KeyCode kc, unsigned int time, MacEventType type, unsigned int txt, unsigned int raw )
 {
 	// set to 1 if this is either a keydown or repeat
 	KeyBuffer[kc] = ( type == MAC_KEYUP ) ? 0 : 1;
 
 	if ( mBuffered && mListener )
-		pendingEvents.push_back( MacKeyStackEvent( KeyEvent(this, kc, txt), type) );
+		pendingEvents.push_back( MacKeyStackEvent( KeyEvent(this, kc, txt, raw, mModifiers), type) );
 }
 
 

--- a/src/win32/Win32KeyBoard.cpp
+++ b/src/win32/Win32KeyBoard.cpp
@@ -145,7 +145,7 @@ void Win32Keyboard::_readBuffered()
 				mModifiers |= Alt;
 
 			if( mListener )
-				ret = mListener->keyPressed( KeyEvent( this, kc, _translateText(kc) ) );
+				ret = mListener->keyPressed( KeyEvent( this, kc, _translateText(kc), kc, mModifiers ) );
 		}
 		else
 		{
@@ -159,7 +159,7 @@ void Win32Keyboard::_readBuffered()
 
 			//Fire off event
 			if( mListener )
-				ret = mListener->keyReleased( KeyEvent( this, kc, 0 ) );
+				ret = mListener->keyReleased( KeyEvent( this, kc, 0, kc, mModifiers ) );
 		}
 
 		if(ret == false)
@@ -185,9 +185,9 @@ void Win32Keyboard::_readBuffered()
 				if (mListener)
 				{
 					if (KeyBuffer[i])
-						ret = mListener->keyPressed( KeyEvent( this, (KeyCode)i, _translateText((KeyCode)i) ) );
+						ret = mListener->keyPressed( KeyEvent( this, (KeyCode)i, _translateText((KeyCode)i), (KeyCode)i, mModifiers ) );
 					else
-						ret = mListener->keyReleased( KeyEvent( this, (KeyCode)i, 0 ) );
+						ret = mListener->keyReleased( KeyEvent( this, (KeyCode)i, 0, (KeyCode)i, mModifiers ) );
 				}
 			}
 


### PR DESCRIPTION
1. integrated pavlos256 'Improve LinuxKeyboard' (pull request #1) with current master
2. support NumLock and CapsLock as modifiers, with correct initial state (currently only for LinuxKeyboard)
3. improve KeyEvent to provide modifiers state and raw key code (need test for non Linux platform)
