### PR TITLE
Fix builds on multilib systems

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ CXXFLAGS="$CXXFLAGS"
 LIBS="$LIBS"
 
 dnl Detect X11
-AC_CHECK_HEADERS([X11/Xlib.h],, [AC_MSG_ERROR("Xlib.h not found - libx11-dev")])
+AC_CHECK_LIB([X11], [XOpenDisplay]),, [AC_MSG_ERROR("X11 library not found - libx11-dev")])
 
 dnl Added for BSD's
 AC_PROG_LIBTOOL

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,6 +20,6 @@ libOIS_la_SOURCES = OISInputManager.cpp \
 libOIS_la_LDFLAGS = -release @PACKAGE_VERSION@
 #libOIS_la_LDFLAGS = -version-info $(shell echo "@PACKAGE_VERSION@" | tr '.' ':')
 
-libOIS_la_LIBADD = $(STLPORT_LIBS) -L/usr/X11R6/lib -lX11
+libOIS_la_LIBADD = $(STLPORT_LIBS)
 
 #eof "$Id: Makefile.am,v 1.15.2.1 2008/02/14 03:33:36 pjcast Exp $"


### PR DESCRIPTION
This attempts to fix issue https://github.com/wgois/OIS/issues/24.

The problem is the `-L/usr/X11R6/lib` in `src/Makefile.am`, on Slackware 64-bit systems it expects it to be in `/usr/X11R6/lib64`. This can be avoided by checking the libraries in the configure.ac with `AC_CHECK_LIB` where it seems to be able of replacing the current `AC_CHECK_HEADERS`. I am not certain `XOpenDisplay` is the best choice to check against, but it seems to work and is a common example when browsing other configure.ac files. One alternative might be `XClearWindow`? Any suggestions to improve this are of course welcome.

I tested this by using ldd on the compiled library where it did not change what it was linked against.

Before
```
$ ldd TMP/usr/local/lib/libOIS-1.4.0.so 
	linux-vdso.so.1 (0x00007ffedbe9c000)
	libX11.so.6 => /usr/lib64/../lib64/libX11.so.6 (0x00007fd03e652000)
	libxcb.so.1 => /usr/lib64/../lib64/libxcb.so.1 (0x00007fd03e42a000)
	libXau.so.6 => /usr/lib64/../lib64/libXau.so.6 (0x00007fd03e222000)
	libXdmcp.so.6 => /usr/lib64/../lib64/libXdmcp.so.6 (0x00007fd03e01a000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00007fd03ddda000)
	libstdc++.so.6 => /usr/lib64/../lib64/libstdc++.so.6 (0x00007fd03da5a000)
	libm.so.6 => /lib64/libm.so.6 (0x00007fd03d74a000)
	libc.so.6 => /lib64/libc.so.6 (0x00007fd03d382000)
	libgcc_s.so.1 => /usr/lib64/../lib64/libgcc_s.so.1 (0x00007fd03d16a000)
	/lib64/ld-linux-x86-64.so.2 (0x0000557d264ef000)
```
After
```
$ ldd TMP/usr/local/lib/libOIS-1.4.0.so
	linux-vdso.so.1 (0x00007fff90dbc000)
	libX11.so.6 => /usr/lib64/../lib64/libX11.so.6 (0x00007fbb999ea000)
	libxcb.so.1 => /usr/lib64/../lib64/libxcb.so.1 (0x00007fbb997c2000)
	libXau.so.6 => /usr/lib64/../lib64/libXau.so.6 (0x00007fbb995ba000)
	libXdmcp.so.6 => /usr/lib64/../lib64/libXdmcp.so.6 (0x00007fbb993b2000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00007fbb99172000)
	libstdc++.so.6 => /usr/lib64/../lib64/libstdc++.so.6 (0x00007fbb98df2000)
	libm.so.6 => /lib64/libm.so.6 (0x00007fbb98ae2000)
	libc.so.6 => /lib64/libc.so.6 (0x00007fbb9871a000)
	libgcc_s.so.1 => /usr/lib64/../lib64/libgcc_s.so.1 (0x00007fbb98502000)
	/lib64/ld-linux-x86-64.so.2 (0x00005648780c1000)
```