### PR TITLE
Fix README instructions for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Linux/
 	Steps to build on Linux:
 	./bootstrap
 	./configure
-	./make && make install
+	make && make install
 
 	---- Configure build options --------------------------------------------
 	./configure --help              --- List all configure options


### PR DESCRIPTION
This fixes a typo in the README file. `./make` would search for a command called `make` in the local directory. This obviously doesn't work; the intent is to use the standard `make` command.