### PR TITLE
fix getAsString for explicit converted keycodes

### DIFF
--- a/includes/linux/LinuxKeyboard.h
+++ b/includes/linux/LinuxKeyboard.h
@@ -125,6 +125,8 @@ namespace OIS
 		
 		typedef std::unordered_map<KeyCode, KeySym> OIStoX_KeyMap;
 		OIStoX_KeyMap keyConversionFromOIS;
+		
+		void addKeyConversion(KeySym x_key, KeyCode ois_key);
 
 		OIS::KeyCode convert(KeySym ksym);
 		KeySym convert(OIS::KeyCode ksym);

--- a/includes/linux/LinuxKeyboard.h
+++ b/includes/linux/LinuxKeyboard.h
@@ -94,10 +94,10 @@ namespace OIS
 			if(keySym != NoSymbol)
 			{
 				//Check for explicit convert
-				OIS::KeyCode converted = convert(keySym);
-				if(converted != KC_UNASSIGNED)
-					return converted;
-
+				const auto result = keyConversionToOIS.find(keySym);
+				if(result != keyConversionToOIS.end())
+					return result->second;
+				
 				::KeyCode xkc = XKeysymToKeycode(display, keySym);
 				if(xkc > 8)
 					return static_cast<KeyCode>(xkc - 8);
@@ -109,11 +109,11 @@ namespace OIS
 		{
 			if(kc == KC_UNASSIGNED)
 				return NoSymbol;
-
+			
 			//Check for explicit convert
-			KeySym converted = convert(kc);
-			if(converted != NoSymbol)
-				return converted;
+			const auto result = keyConversionFromOIS.find(kc);
+			if(result != keyConversionFromOIS.end())
+				return result->second;
 			
 			::KeyCode xkc = kc + 8;
 			return XkbKeycodeToKeysym(display, xkc, 0, 0);
@@ -127,9 +127,6 @@ namespace OIS
 		OIStoX_KeyMap keyConversionFromOIS;
 		
 		void addKeyConversion(KeySym x_key, KeyCode ois_key);
-
-		OIS::KeyCode convert(KeySym ksym);
-		KeySym convert(OIS::KeyCode ksym);
 
 		//! Depressed Key List
 		char KeyBuffer[256];

--- a/includes/linux/LinuxKeyboard.h
+++ b/includes/linux/LinuxKeyboard.h
@@ -110,16 +110,24 @@ namespace OIS
 			if(kc == KC_UNASSIGNED)
 				return NoSymbol;
 
+			//Check for explicit convert
+			KeySym converted = convert(kc);
+			if(converted != NoSymbol)
+				return converted;
+			
 			::KeyCode xkc = kc + 8;
-
 			return XkbKeycodeToKeysym(display, xkc, 0, 0);
 		}
 
 		//! Explict convertion for non-text symbols
 		typedef std::unordered_map<KeySym, KeyCode> XtoOIS_KeyMap;
-		XtoOIS_KeyMap keyConversion;
+		XtoOIS_KeyMap keyConversionToOIS;
+		
+		typedef std::unordered_map<KeyCode, KeySym> OIStoX_KeyMap;
+		OIStoX_KeyMap keyConversionFromOIS;
 
 		OIS::KeyCode convert(KeySym ksym);
+		KeySym convert(OIS::KeyCode ksym);
 
 		//! Depressed Key List
 		char KeyBuffer[256];

--- a/src/linux/LinuxKeyboard.cpp
+++ b/src/linux/LinuxKeyboard.cpp
@@ -35,10 +35,6 @@ following restrictions:
 using namespace OIS;
 #include <iostream>
 
-#define ADD_KEY_CONVERSION(x_key, ois_key) \
-	keyConversionToOIS.insert(XtoOIS_KeyMap::value_type(x_key, ois_key)); \
-	keyConversionFromOIS.insert(OIStoX_KeyMap::value_type(ois_key, x_key));
-
 //-------------------------------------------------------------------//
 LinuxKeyboard::LinuxKeyboard(InputManager* creator, bool buffered, bool grab) :
  Keyboard(creator->inputSystemName(), buffered, 0, creator), xim(0), ximStyle(0), xic(0)
@@ -52,47 +48,52 @@ LinuxKeyboard::LinuxKeyboard(InputManager* creator, bool buffered, bool grab) :
 	static_cast<LinuxInputManager*>(mCreator)->_setKeyboardUsed(true);
 
 	
-	ADD_KEY_CONVERSION(XK_Up, KC_UP);
-	ADD_KEY_CONVERSION(XK_Down, KC_DOWN);
-	ADD_KEY_CONVERSION(XK_Left, KC_LEFT);
-	ADD_KEY_CONVERSION(XK_Right, KC_RIGHT);
+	addKeyConversion(XK_Up, KC_UP);
+	addKeyConversion(XK_Down, KC_DOWN);
+	addKeyConversion(XK_Left, KC_LEFT);
+	addKeyConversion(XK_Right, KC_RIGHT);
 
-	ADD_KEY_CONVERSION(XK_KP_Divide, KC_DIVIDE);
+	addKeyConversion(XK_KP_Divide, KC_DIVIDE);
 
-	ADD_KEY_CONVERSION(XK_KP_Home, KC_NUMPAD7);
-	ADD_KEY_CONVERSION(XK_KP_Up, KC_NUMPAD8);
-	ADD_KEY_CONVERSION(XK_KP_Page_Up, KC_NUMPAD9);
-	ADD_KEY_CONVERSION(XK_KP_Left, KC_NUMPAD4);
-	ADD_KEY_CONVERSION(XK_KP_Begin, KC_NUMPAD5);
-	ADD_KEY_CONVERSION(XK_KP_Right, KC_NUMPAD6);
-	ADD_KEY_CONVERSION(XK_KP_End, KC_NUMPAD1);
-	ADD_KEY_CONVERSION(XK_KP_Down, KC_NUMPAD2);
-	ADD_KEY_CONVERSION(XK_KP_Page_Down, KC_NUMPAD3);
-	ADD_KEY_CONVERSION(XK_KP_Insert, KC_NUMPAD0);
-	ADD_KEY_CONVERSION(XK_KP_Delete, KC_DECIMAL);
+	addKeyConversion(XK_KP_Home, KC_NUMPAD7);
+	addKeyConversion(XK_KP_Up, KC_NUMPAD8);
+	addKeyConversion(XK_KP_Page_Up, KC_NUMPAD9);
+	addKeyConversion(XK_KP_Left, KC_NUMPAD4);
+	addKeyConversion(XK_KP_Begin, KC_NUMPAD5);
+	addKeyConversion(XK_KP_Right, KC_NUMPAD6);
+	addKeyConversion(XK_KP_End, KC_NUMPAD1);
+	addKeyConversion(XK_KP_Down, KC_NUMPAD2);
+	addKeyConversion(XK_KP_Page_Down, KC_NUMPAD3);
+	addKeyConversion(XK_KP_Insert, KC_NUMPAD0);
+	addKeyConversion(XK_KP_Delete, KC_DECIMAL);
 
-	ADD_KEY_CONVERSION(XK_Page_Up, KC_PGUP);
-	ADD_KEY_CONVERSION(XK_Page_Down, KC_PGDOWN);
-	ADD_KEY_CONVERSION(XK_Home, KC_HOME);
-	ADD_KEY_CONVERSION(XK_End, KC_END);
+	addKeyConversion(XK_Page_Up, KC_PGUP);
+	addKeyConversion(XK_Page_Down, KC_PGDOWN);
+	addKeyConversion(XK_Home, KC_HOME);
+	addKeyConversion(XK_End, KC_END);
 
-	ADD_KEY_CONVERSION(XK_Print, KC_SYSRQ);
-	ADD_KEY_CONVERSION(XK_Scroll_Lock, KC_SCROLL);
-	ADD_KEY_CONVERSION(XK_Pause, KC_PAUSE);
+	addKeyConversion(XK_Print, KC_SYSRQ);
+	addKeyConversion(XK_Scroll_Lock, KC_SCROLL);
+	addKeyConversion(XK_Pause, KC_PAUSE);
 
-	ADD_KEY_CONVERSION(XK_Shift_R, KC_RSHIFT);
-	ADD_KEY_CONVERSION(XK_Shift_L, KC_LSHIFT);
-	ADD_KEY_CONVERSION(XK_Alt_R, KC_RMENU);
-	ADD_KEY_CONVERSION(XK_Alt_L, KC_LMENU);
+	addKeyConversion(XK_Shift_R, KC_RSHIFT);
+	addKeyConversion(XK_Shift_L, KC_LSHIFT);
+	addKeyConversion(XK_Alt_R, KC_RMENU);
+	addKeyConversion(XK_Alt_L, KC_LMENU);
 
-	ADD_KEY_CONVERSION(XK_Insert, KC_INSERT);
-	ADD_KEY_CONVERSION(XK_Delete, KC_DELETE);
+	addKeyConversion(XK_Insert, KC_INSERT);
+	addKeyConversion(XK_Delete, KC_DELETE);
 
-	ADD_KEY_CONVERSION(XK_Super_L, KC_LWIN);
-	ADD_KEY_CONVERSION(XK_Super_R, KC_RWIN);
-	ADD_KEY_CONVERSION(XK_Menu, KC_APPS);
+	addKeyConversion(XK_Super_L, KC_LWIN);
+	addKeyConversion(XK_Super_R, KC_RWIN);
+	addKeyConversion(XK_Menu, KC_APPS);
 }
 
+void LinuxKeyboard::addKeyConversion(KeySym x_key, KeyCode ois_key)
+{
+	keyConversionToOIS.insert(XtoOIS_KeyMap::value_type(x_key, ois_key));
+	keyConversionFromOIS.insert(OIStoX_KeyMap::value_type(ois_key, x_key));
+}
 //-------------------------------------------------------------------//
 void LinuxKeyboard::_initialize()
 {

--- a/src/linux/LinuxKeyboard.cpp
+++ b/src/linux/LinuxKeyboard.cpp
@@ -35,6 +35,10 @@ following restrictions:
 using namespace OIS;
 #include <iostream>
 
+#define ADD_KEY_CONVERSION(x_key, ois_key) \
+	keyConversionToOIS.insert(XtoOIS_KeyMap::value_type(x_key, ois_key)); \
+	keyConversionFromOIS.insert(OIStoX_KeyMap::value_type(ois_key, x_key));
+
 //-------------------------------------------------------------------//
 LinuxKeyboard::LinuxKeyboard(InputManager* creator, bool buffered, bool grab) :
  Keyboard(creator->inputSystemName(), buffered, 0, creator), xim(0), ximStyle(0), xic(0)
@@ -47,45 +51,46 @@ LinuxKeyboard::LinuxKeyboard(InputManager* creator, bool buffered, bool grab) :
 
 	static_cast<LinuxInputManager*>(mCreator)->_setKeyboardUsed(true);
 
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Up, KC_UP));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Down, KC_DOWN));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Left, KC_LEFT));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Right, KC_RIGHT));
+	
+	ADD_KEY_CONVERSION(XK_Up, KC_UP);
+	ADD_KEY_CONVERSION(XK_Down, KC_DOWN);
+	ADD_KEY_CONVERSION(XK_Left, KC_LEFT);
+	ADD_KEY_CONVERSION(XK_Right, KC_RIGHT);
 
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_Divide, KC_DIVIDE));
+	ADD_KEY_CONVERSION(XK_KP_Divide, KC_DIVIDE);
 
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_Home, KC_NUMPAD7));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_Up, KC_NUMPAD8));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_Page_Up, KC_NUMPAD9));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_Left, KC_NUMPAD4));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_Begin, KC_NUMPAD5));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_Right, KC_NUMPAD6));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_End, KC_NUMPAD1));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_Down, KC_NUMPAD2));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_Page_Down, KC_NUMPAD3));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_Insert, KC_NUMPAD0));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_KP_Delete, KC_DECIMAL));
+	ADD_KEY_CONVERSION(XK_KP_Home, KC_NUMPAD7);
+	ADD_KEY_CONVERSION(XK_KP_Up, KC_NUMPAD8);
+	ADD_KEY_CONVERSION(XK_KP_Page_Up, KC_NUMPAD9);
+	ADD_KEY_CONVERSION(XK_KP_Left, KC_NUMPAD4);
+	ADD_KEY_CONVERSION(XK_KP_Begin, KC_NUMPAD5);
+	ADD_KEY_CONVERSION(XK_KP_Right, KC_NUMPAD6);
+	ADD_KEY_CONVERSION(XK_KP_End, KC_NUMPAD1);
+	ADD_KEY_CONVERSION(XK_KP_Down, KC_NUMPAD2);
+	ADD_KEY_CONVERSION(XK_KP_Page_Down, KC_NUMPAD3);
+	ADD_KEY_CONVERSION(XK_KP_Insert, KC_NUMPAD0);
+	ADD_KEY_CONVERSION(XK_KP_Delete, KC_DECIMAL);
 
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Page_Up, KC_PGUP));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Page_Down, KC_PGDOWN));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Home, KC_HOME));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_End, KC_END));
+	ADD_KEY_CONVERSION(XK_Page_Up, KC_PGUP);
+	ADD_KEY_CONVERSION(XK_Page_Down, KC_PGDOWN);
+	ADD_KEY_CONVERSION(XK_Home, KC_HOME);
+	ADD_KEY_CONVERSION(XK_End, KC_END);
 
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Print, KC_SYSRQ));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Scroll_Lock, KC_SCROLL));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Pause, KC_PAUSE));
+	ADD_KEY_CONVERSION(XK_Print, KC_SYSRQ);
+	ADD_KEY_CONVERSION(XK_Scroll_Lock, KC_SCROLL);
+	ADD_KEY_CONVERSION(XK_Pause, KC_PAUSE);
 
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Shift_R, KC_RSHIFT));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Shift_L, KC_LSHIFT));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Alt_R, KC_RMENU));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Alt_L, KC_LMENU));
+	ADD_KEY_CONVERSION(XK_Shift_R, KC_RSHIFT);
+	ADD_KEY_CONVERSION(XK_Shift_L, KC_LSHIFT);
+	ADD_KEY_CONVERSION(XK_Alt_R, KC_RMENU);
+	ADD_KEY_CONVERSION(XK_Alt_L, KC_LMENU);
 
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Insert, KC_INSERT));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Delete, KC_DELETE));
+	ADD_KEY_CONVERSION(XK_Insert, KC_INSERT);
+	ADD_KEY_CONVERSION(XK_Delete, KC_DELETE);
 
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Super_L, KC_LWIN));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Super_R, KC_RWIN));
-	keyConversion.insert(XtoOIS_KeyMap::value_type(XK_Menu, KC_APPS));
+	ADD_KEY_CONVERSION(XK_Super_L, KC_LWIN);
+	ADD_KEY_CONVERSION(XK_Super_R, KC_RWIN);
+	ADD_KEY_CONVERSION(XK_Menu, KC_APPS);
 }
 
 //-------------------------------------------------------------------//
@@ -367,9 +372,16 @@ void LinuxKeyboard::setBuffered(bool buffered)
 
 OIS::KeyCode LinuxKeyboard::convert(KeySym kc)
 {
-	const auto result = keyConversion.find(kc);
-	if(result == keyConversion.end())
+	const auto result = keyConversionToOIS.find(kc);
+	if(result == keyConversionToOIS.end())
 		return KC_UNASSIGNED; //No explicit conversion for the symbol;
+	return result->second;
+}
+KeySym LinuxKeyboard::convert(OIS::KeyCode kc)
+{
+	const auto result = keyConversionFromOIS.find(kc);
+	if(result == keyConversionFromOIS.end())
+		return NoSymbol; //No explicit conversion for the symbol;
 	return result->second;
 }
 //-------------------------------------------------------------------//
@@ -435,7 +447,7 @@ OIS::KeyCode LinuxKeyboard::getAsKeyCode(std::string str)
 	/*
  * TODO fixme!
     KeySym X11Key = XStringToKeysym(str.c_str());
-    mGetKeyCode = keyConversion.at(X11Key);
+    mGetKeyCode = keyConversionToOIS.at(X11Key);
 */
 	return mGetKeyCode;
 }

--- a/src/linux/LinuxKeyboard.cpp
+++ b/src/linux/LinuxKeyboard.cpp
@@ -371,20 +371,6 @@ void LinuxKeyboard::setBuffered(bool buffered)
 	mBuffered = buffered;
 }
 
-OIS::KeyCode LinuxKeyboard::convert(KeySym kc)
-{
-	const auto result = keyConversionToOIS.find(kc);
-	if(result == keyConversionToOIS.end())
-		return KC_UNASSIGNED; //No explicit conversion for the symbol;
-	return result->second;
-}
-KeySym LinuxKeyboard::convert(OIS::KeyCode kc)
-{
-	const auto result = keyConversionFromOIS.find(kc);
-	if(result == keyConversionFromOIS.end())
-		return NoSymbol; //No explicit conversion for the symbol;
-	return result->second;
-}
 //-------------------------------------------------------------------//
 bool LinuxKeyboard::_injectKeyDown(KeyCode kc, int text)
 {

--- a/src/linux/LinuxKeyboard.cpp
+++ b/src/linux/LinuxKeyboard.cpp
@@ -430,13 +430,8 @@ const std::string& LinuxKeyboard::getAsString(KeyCode kc)
 //-------------------------------------------------------------------//
 OIS::KeyCode LinuxKeyboard::getAsKeyCode(std::string str)
 {
-	OIS::KeyCode mGetKeyCode;
-	/*
- * TODO fixme!
-    KeySym X11Key = XStringToKeysym(str.c_str());
-    mGetKeyCode = keyConversionToOIS.at(X11Key);
-*/
-	return mGetKeyCode;
+	KeySym X11Key = XStringToKeysym(str.c_str());
+	return KeySymToOISKeyCode(X11Key);
 }
 
 //-------------------------------------------------------------------//


### PR DESCRIPTION
**Summary of changes**

Currently `getAsString()` for explicit converted keycodes (eg. arrows keys) show incorrect key name (eg. "XF86AudioPlay" instead of "Down"). Add full reverse mapping for fix this.

**Affected backeds (X11)**
