### PR TITLE
Additional Left/Right Modifiers + Win

### DIFF
--- a/includes/OISKeyboard.h
+++ b/includes/OISKeyboard.h
@@ -278,11 +278,20 @@ namespace OIS
 
 		//! Enum of bit position of modifer
 		enum Modifier {
-			Shift	= 0x0000001,
+			Shift	 = 0x0000001,
+			LShift	 = 0x0000002,
+			RShift	 = 0x0000004,
 			Ctrl	 = 0x0000010,
-			Alt		 = 0x0000100,
+			LCtrl	 = 0x0000020,
+			RCtrl	 = 0x0000040,
+			Alt	 = 0x0000100,
+			LAlt	 = 0x0000200,
+			RAlt	 = 0x0000400,
 			CapsLock = 0x0001000,
-			NumLock  = 0x0010000
+			NumLock  = 0x0010000,
+			Win	 = 0x0100000,
+			LWin	 = 0x0200000,
+			RWin	 = 0x0400000
 		};
 
 		/**
@@ -302,6 +311,12 @@ namespace OIS
 			Check modifier status
 		*/
 		bool isModifierDown(Modifier mod) const;
+		
+		/**
+		@remarks
+			Returns the full modifiers status bit field
+		*/
+		unsigned int getModifiers() const;
 
 		/**
 		@remarks
@@ -315,7 +330,7 @@ namespace OIS
 		 Object(vendor, OISKeyboard, buffered, devID, creator),
 		 mModifiers(0), mListener(0), mTextMode(Unicode) {}
 
-		//! Bit field that holds status of Alt, Ctrl, Shift
+		//! Bit field that holds status of Alt, Ctrl, Shift, Win, CapsLock, and NumLock as well as Left and Right variants
 		unsigned int mModifiers;
 
 		//! Used for buffered/actionmapping callback

--- a/src/OISKeyboard.cpp
+++ b/src/OISKeyboard.cpp
@@ -46,3 +46,9 @@ bool Keyboard::isModifierDown(Modifier mod) const
 #pragma warning(pop)
 #endif
 }
+
+//----------------------------------------------------------------------//
+unsigned int Keyboard::getModifiers() const
+{
+	return mModifiers;
+}

--- a/src/win32/Win32KeyBoard.cpp
+++ b/src/win32/Win32KeyBoard.cpp
@@ -140,12 +140,34 @@ void Win32Keyboard::_readBuffered()
 		if(diBuff[i].dwData & 0x80)
 		{
 			//Turn on modifier
-			if(kc == KC_LCONTROL || kc == KC_RCONTROL)
+			if(kc == KC_LCONTROL || kc == KC_RCONTROL) {
 				mModifiers |= Ctrl;
-			else if(kc == KC_LSHIFT || kc == KC_RSHIFT)
+				if (kc == KC_LCONTROL)
+					mModifiers |= LCtrl;
+				else if (kc == KC_RCONTROL)
+					mModifiers |= RCtrl;
+			}
+			else if(kc == KC_LSHIFT || kc == KC_RSHIFT) {
 				mModifiers |= Shift;
-			else if(kc == KC_LMENU || kc == KC_RMENU)
+				if (kc == KC_LSHIFT)
+					mModifiers |= LShift;
+				else if (kc == KC_RSHIFT)
+					mModifiers |= RShift;
+			}
+			else if(kc == KC_LMENU || kc == KC_RMENU) {
 				mModifiers |= Alt;
+				if (kc == KC_LMENU)
+					mModifiers |= LAlt;
+				else if (kc == KC_RMENU)
+					mModifiers |= RAlt;
+			}
+			else if(kc == KC_LWIN || kc == KC_RWIN) {
+				mModifiers |= Win;
+				if (kc == KC_LWIN)
+					mModifiers |= LWin;
+				else if (kc == KC_RWIN)
+					mModifiers |= RWin;
+			}
 
 			//These ones are toggled when
 			else if (kc == KC_NUMLOCK)
@@ -170,12 +192,42 @@ void Win32Keyboard::_readBuffered()
 		else
 		{
 			//Turn off modifier
-			if(kc == KC_LCONTROL || kc == KC_RCONTROL)
-				mModifiers &= ~Ctrl;
-			else if(kc == KC_LSHIFT || kc == KC_RSHIFT)
-				mModifiers &= ~Shift;
-			else if(kc == KC_LMENU || kc == KC_RMENU)
-				mModifiers &= ~Alt;
+			if(kc == KC_LCONTROL || kc == KC_RCONTROL) {
+				if (kc == KC_LCONTROL)
+					mModifiers &= ~LCtrl;
+				else if (kc == KC_RCONTROL)
+					mModifiers &= ~RCtrl;
+				//Only disable combined modifier if both L/R are disabled
+				if (!(mModifiers & LCtrl) && !(mModifiers & RCtrl))
+					mModifiers &= ~Ctrl;
+			}
+			else if(kc == KC_LSHIFT || kc == KC_RSHIFT) {
+				if (kc == KC_LSHIFT)
+					mModifiers &= ~LShift;
+				else if (kc == KC_RSHIFT)
+					mModifiers &= ~RShift;
+				//Only disable combined modifier if both L/R are disabled
+				if (!(mModifiers & LShift) && !(mModifiers & RShift))
+					mModifiers &= ~Shift;
+			}
+			else if(kc == KC_LMENU || kc == KC_RMENU) {
+				if (kc == KC_LMENU)
+					mModifiers &= ~LAlt;
+				else if (kc == KC_RMENU)
+					mModifiers &= ~RAlt;
+				//Only disable combined modifier if both L/R are disabled
+				if (!(mModifiers & LAlt) && !(mModifiers & RAlt))
+					mModifiers &= ~Alt;
+			}
+			else if(kc == KC_LWIN || kc == KC_RWIN) {
+				if (kc == KC_LWIN)
+					mModifiers &= ~LWin;
+				else if (kc == KC_RWIN)
+					mModifiers &= ~RWin;
+				//Only disable combined modifier if both L/R are disabled
+				if (!(mModifiers & LWin) && !(mModifiers & RWin))
+					mModifiers &= ~Win;
+			}
 
 			//Fire off event
 			if(mListener)
@@ -232,14 +284,36 @@ void Win32Keyboard::_read()
 			mKeyboard->GetDeviceState(sizeof(KeyBuffer), &KeyBuffer);
 	}
 
-	//Set Shift, Ctrl, Alt
+	//Set Shift, Ctrl, Alt, Win, CapsLock, and NumLock as well as Left and Right variants
 	mModifiers = 0;
 	if(isKeyDown(KC_LCONTROL) || isKeyDown(KC_RCONTROL))
 		mModifiers |= Ctrl;
+	if(isKeyDown(KC_LCONTROL))
+		mModifiers |= LCtrl;
+	if(isKeyDown(KC_RCONTROL))
+		mModifiers |= RCtrl;
 	if(isKeyDown(KC_LSHIFT) || isKeyDown(KC_RSHIFT))
 		mModifiers |= Shift;
+	if(isKeyDown(KC_LSHIFT))
+		mModifiers |= LShift;
+	if(isKeyDown(KC_RSHIFT))
+		mModifiers |= RShift;
 	if(isKeyDown(KC_LMENU) || isKeyDown(KC_RMENU))
 		mModifiers |= Alt;
+	if(isKeyDown(KC_LMENU))
+		mModifiers |= LAlt;
+	if(isKeyDown(KC_RMENU))
+		mModifiers |= RAlt;
+	if(isKeyDown(KC_LWIN) || isKeyDown(KC_RWIN))
+		mModifiers |= Win;
+	if(isKeyDown(KC_LWIN))
+		mModifiers |= LWin;
+	if(isKeyDown(KC_RWIN))
+		mModifiers |= RWin;
+	if(isKeyDown(KC_CAPITAL))
+		mModifiers |= CapsLock;
+	if(isKeyDown(KC_NUMLOCK))
+		mModifiers |= NumLock;
 }
 
 //--------------------------------------------------------------------------------------------------//


### PR DESCRIPTION
**Summary of changes**

Only affects Win32KeyBoard, as I'm unfamiliar with how to make similar changes in the other keyboards.

* Add Left and Right Variants of Ctrl, Shift, and Alt Modifiers (Existing modifier values unchanged)
* Add additional Windows key modifier (Left, right and combined)
* Add convenient function to return the whole modifier bit field

With left and/or right modifiers active, the combined modifier is also active.  Both left/right must be inactive for the combined modifier to deactivate.  This should only affect client code if they are comparing the entire bit field.  However, the function to return the full bit field did not exist before this pull request.