### PR TITLE
Add missing sliderMoved event handler

### DIFF
--- a/demos/OISConsoleDemo/OISConsole.cpp
+++ b/demos/OISConsoleDemo/OISConsole.cpp
@@ -160,6 +160,14 @@ public:
 					  << arg.device->vendor() << ". Axis # " << axis << " Value: " << arg.state.mAxes[axis].abs;
 		return true;
 	}
+	bool sliderMoved(const JoyStickEvent& arg, int index)
+	{
+		std::cout << std::endl
+				  << arg.device->vendor() << ". Slider # " << index 
+				  << " X Value: " << arg.state.mSliders[index].abX
+				  << " Y Value: " << arg.state.mSliders[index].abY;
+		return true;
+	}
 	bool povMoved(const JoyStickEvent& arg, int pov)
 	{
 		std::cout << std::endl


### PR DESCRIPTION
**Summary of changes**
- Add sliderMoved event handler in OISConsoleDemo app

**Affected backeds (DirectInput, X11... Fill in if applicable)**
- DirectInput is the only backend that raises sliderMoved events