### PR TITLE
don't wrap not moved linux mouse

### DIFF
--- a/src/linux/LinuxMouse.cpp
+++ b/src/linux/LinuxMouse.cpp
@@ -203,7 +203,7 @@ void LinuxMouse::_processXEvents()
 				if(mouseFocusLost == false)
 				{
 					//Keep mouse in window (fudge factor)
-					if(event.xmotion.x < 100 || event.xmotion.x > mState.width - 100 || event.xmotion.y < 100 || event.xmotion.y > mState.height - 100)
+					if( (event.xmotion.x < 100 || event.xmotion.x > mState.width - 100 || event.xmotion.y < 100 || event.xmotion.y > mState.height - 100) && (dx!=0 || dy!=0) )
 					{
 						oldXMouseX = mState.width >> 1;	 //center x
 						oldXMouseY = mState.height >> 1; //center y


### PR DESCRIPTION
**Summary of changes**

Block mouse wrapping on event with zero move (this events may be received after use XWarpPointer when pointer was not moved), to avoid event repeat-loop.

Event repeat-loop can occurs when move event (generated by wrap pointer) was received in next call of capture() (so can't be blocked by mWarped).

**Affected backeds: X11**
