### PR TITLE
Non-Exclusive LinuxMouse Offset Bugfix

### DIFF
--- a/includes/mac/CocoaInputManager.h
+++ b/includes/mac/CocoaInputManager.h
@@ -86,6 +86,7 @@ namespace OIS
 
 		// settings
 		bool mHideMouse;
+                float mMonitorScale;
 		bool mUseRepeat;
 
 		//! Used to know if we used up keyboard

--- a/includes/mac/CocoaMouse.h
+++ b/includes/mac/CocoaMouse.h
@@ -40,7 +40,7 @@ namespace OIS
 	class CocoaMouse : public Mouse
 	{
 	public:
-		CocoaMouse(InputManager* creator, bool buffered);
+		CocoaMouse(InputManager* creator, bool buffered, bool hiddenMouse, float hiDPI_Scale);
 		virtual ~CocoaMouse();
 
 		/** @copydoc Object::setBuffered */
@@ -67,9 +67,13 @@ namespace OIS
 	MouseState mTempState;
 	bool mNeedsToRegainFocus;
 	bool mMouseWarped;
+        bool mMouseIsHidden;
+        float mMonitorScaling;
 }
 
 - (void)setOISMouseObj:(CocoaMouse*)obj;
+- (void)setHiddenMouse:(bool)hiddenMouse;
+- (void)setMonitorScaling:(float)hiDPI_Scale;
 - (void)capture;
 
 @end

--- a/includes/mac/MacInputManager.h
+++ b/includes/mac/MacInputManager.h
@@ -90,6 +90,7 @@ namespace OIS
 		// settings
 		bool mHideMouse;
 		bool mUseRepeat;
+                bool mNonExclusiveMouse;
 
 		//! Used to know if we used up keyboard
 		bool keyboardUsed;

--- a/includes/mac/MacMouse.h
+++ b/includes/mac/MacMouse.h
@@ -38,7 +38,7 @@ namespace OIS
 	class MacMouse : public Mouse
 	{
 	public:
-		MacMouse(InputManager* creator, bool buffered);
+		MacMouse(InputManager* creator, bool buffered, bool nonExclusive);
 		virtual ~MacMouse();
 
 		/** @copydoc Object::setBuffered */
@@ -68,6 +68,7 @@ namespace OIS
 
 		bool mNeedsToRegainFocus;
 		bool mMouseWarped;
+                bool mMouseNonExclusive;
 
 		MouseState mTempState;
 	};

--- a/src/linux/LinuxMouse.cpp
+++ b/src/linux/LinuxMouse.cpp
@@ -182,10 +182,19 @@ void LinuxMouse::_processXEvents()
 			oldXMouseX = event.xmotion.x;
 			oldXMouseY = event.xmotion.y;
 
-			mState.X.abs += dx;
-			mState.Y.abs += dy;
-			mState.X.rel += dx;
-			mState.Y.rel += dy;
+			//Move the mouse
+			if(grabMouse && mouseFocusLost == false)
+			{
+				mState.X.abs += dx;
+				mState.Y.abs += dy;
+				mState.X.rel += dx;
+				mState.Y.rel += dy;
+			}
+			else
+			{
+				mState.X.abs = event.xmotion.x;
+				mState.Y.abs = event.xmotion.y;
+			}
 
 			//Check to see if we are grabbing the mouse to the window (requires clipping and warping)
 			if(grabMouse)

--- a/src/mac/CocoaInputManager.mm
+++ b/src/mac/CocoaInputManager.mm
@@ -40,6 +40,7 @@ CocoaInputManager::CocoaInputManager() :
 	mHideMouse = true;
 	mUseRepeat = false;
 	mWindow	= nil;
+        mMonitorScale = 1;
 
 	keyboardUsed = mouseUsed = false;
 
@@ -99,6 +100,22 @@ void CocoaInputManager::_parseConfigSettings(ParamList& paramList)
 			mUseRepeat = true;
 		}
 	}
+    
+        if(paramList.find("MacNonexclusiveMouse") != paramList.end())
+        {
+            if(paramList.find("MacNonexclusiveMouse")->second == "true")
+            {
+                mHideMouse = false;
+            }
+        }
+    
+    if(paramList.find("HiDPIMonitorScaling") != paramList.end())
+    {
+        mMonitorScale = std::stof(paramList.find("HiDPIMonitorScaling")->second);
+    }
+    
+    
+    
 }
 
 //--------------------------------------------------------------------------------//
@@ -167,7 +184,7 @@ Object* CocoaInputManager::createObject(InputManager* creator, Type iType, bool 
 		case OISMouse:
 		{
 			if(mouseUsed == false)
-				obj = new CocoaMouse(this, bufferMode);
+				obj = new CocoaMouse(this, bufferMode, mHideMouse, mMonitorScale );
 			break;
 		}
 		default:

--- a/src/mac/CocoaKeyboard.mm
+++ b/src/mac/CocoaKeyboard.mm
@@ -201,6 +201,13 @@ void CocoaKeyboard::copyKeyStates(char keys[256]) const
 	keyConversion.insert(VirtualtoOIS_KeyMap::value_type(0x1D, KC_0));
 
 	keyConversion.insert(VirtualtoOIS_KeyMap::value_type(0x33, KC_BACK)); // might be wrong
+    
+        keyConversion.insert(VirtualtoOIS_KeyMap::value_type(0x39, KC_LSHIFT));
+        keyConversion.insert(VirtualtoOIS_KeyMap::value_type(0x3C, KC_RSHIFT));
+        keyConversion.insert(VirtualtoOIS_KeyMap::value_type(0x3B, KC_LCONTROL));
+        //keyConversion.insert(VirtualtoOIS_KeyMap::value_type(0x2B, KC_RCONTROL));
+        keyConversion.insert(VirtualtoOIS_KeyMap::value_type(0x3A, KC_LMENU));
+        keyConversion.insert(VirtualtoOIS_KeyMap::value_type(0x3D, KC_RMENU));
 
 	keyConversion.insert(VirtualtoOIS_KeyMap::value_type(0x1B, KC_MINUS));
 	keyConversion.insert(VirtualtoOIS_KeyMap::value_type(0x18, KC_EQUALS));
@@ -440,6 +447,52 @@ void CocoaKeyboard::copyKeyStates(char keys[256]) const
 	if([theEvent keyCode] == NSClearLineFunctionKey) // numlock
 		[self injectEvent:KC_NUMLOCK eventTime:time eventType:newstate];
 
+
+    if([theEvent keyCode] == 59) // Ctrl
+    {
+        if(KeyBuffer[59])
+        {
+            [self injectEvent:KC_LCONTROL eventTime:time eventType:MAC_KEYUP eventText:59];
+            KeyBuffer[59] = 0;
+        }
+        else
+        {
+            [self injectEvent:KC_LCONTROL eventTime:time eventType:MAC_KEYDOWN eventText:59];
+            KeyBuffer[59] = 1;
+        }
+    }
+    
+    if([theEvent keyCode] == 58) // Alt
+    {
+        if(KeyBuffer[58])
+        {
+            [self injectEvent:KC_LMENU eventTime:time eventType:MAC_KEYUP eventText:58];
+            KeyBuffer[58] = 0;
+        }
+        else
+        {
+            [self injectEvent:KC_LMENU eventTime:time eventType:MAC_KEYDOWN eventText:58];
+            KeyBuffer[58] = 1;
+        }
+        
+      
+    }
+
+    if([theEvent keyCode] == 57) // Shift
+    {
+        if(KeyBuffer[57])
+        {
+            [self injectEvent:KC_LSHIFT eventTime:time eventType:MAC_KEYUP eventText:57];
+            KeyBuffer[57] = 0;
+        }
+        else
+        {
+            [self injectEvent:KC_LSHIFT eventTime:time eventType:MAC_KEYDOWN eventText:57];
+            KeyBuffer[57] = 1;
+        }
+    }
+
+    
 	prevModMask = mods;
 }
 

--- a/src/mac/MacInputManager.cpp
+++ b/src/mac/MacInputManager.cpp
@@ -45,6 +45,7 @@ MacInputManager::MacInputManager() :
 {
 	mHideMouse		= true;
 	mUseRepeat		= false;
+        mNonExclusiveMouse = false;
 	mEventTargetRef = NULL;
 	mWindow			= NULL;
 
@@ -121,6 +122,14 @@ void MacInputManager::_parseConfigSettings(ParamList& paramList)
 			mUseRepeat = true;
 		}
 	}
+    
+    if(paramList.find("MacNonExclusiveMouse") != paramList.end())
+    {
+        if(paramList.find("MacNonExclusiveMouse")->second == "true")
+        {
+            mNonExclusiveMouse = true;
+        }
+    }
 }
 
 //--------------------------------------------------------------------------------//
@@ -187,7 +196,7 @@ Object* MacInputManager::createObject(InputManager* creator, Type iType, bool bu
 		}
 		case OISMouse: {
 			if(mouseUsed == false)
-				obj = new MacMouse(this, bufferMode);
+				obj = new MacMouse(this, bufferMode, mNonExclusiveMouse);
 			break;
 		}
 		default: {

--- a/src/mac/MacKeyboard.cpp
+++ b/src/mac/MacKeyboard.cpp
@@ -356,6 +356,14 @@ void MacKeyboard::populateKeyConversion()
 	keyConversion.insert(VirtualtoOIS_KeyMap::value_type(0x1D, KC_0));
 
 	keyConversion.insert(VirtualtoOIS_KeyMap::value_type(0x33, KC_BACK)); // might be wrong
+    
+        //Missing ModKeys
+        keyConversion.insert(VirtualtoOIS_KeyMap::value_type(0x39, KC_LSHIFT));
+        keyConversion.insert(VirtualtoOIS_KeyMap::value_type(0x3C, KC_RSHIFT));
+        keyConversion.insert(VirtualtoOIS_KeyMap::value_type(0x3B, KC_LCONTROL));
+        //keyConversion.insert(VirtualtoOIS_KeyMap::value_type(0x2B, KC_RCONTROL));
+        keyConversion.insert(VirtualtoOIS_KeyMap::value_type(0x3A, KC_LMENU));
+        keyConversion.insert(VirtualtoOIS_KeyMap::value_type(0x3D, KC_RMENU));
 
 	keyConversion.insert(VirtualtoOIS_KeyMap::value_type(0x1B, KC_MINUS));
 	keyConversion.insert(VirtualtoOIS_KeyMap::value_type(0x18, KC_EQUALS));


### PR DESCRIPTION
Fixes https://github.com/wgois/OIS/issues/93

We only change the mouse positions if the mouse is grabbed and we have focus. Otherwise, we get an offset. If we don't have the mouse grabbed, or mouse focus is lost, just pipe in the Xmotion values directly. 

The code could probably be merged into the clipping/warping if(grabMouse) conditional below. But I believe this is cleaner with less nesting. 

**Affected backends**
Linux X11 Mouse.
