### PR TITLE
Require CMake 3.10 or newer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,7 +218,6 @@ endif()
 if(UNIX)
 
     if (NOT APPLE)
-        add_dependencies(OIS X11)
         target_link_libraries(OIS X11)
     endif()
 


### PR DESCRIPTION
**Summary of changes**
Increase minimum required version of CMake to 3.10.

**Affected backeds (DirectInput, X11... Fill in if applicable)**
does not apply